### PR TITLE
remove CppMediaServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ code first：(10行以内的代码展示项目)
 * [cpp-ipc](#cpp-ipc)
 * [luatinkerE](#luatinkerE)
 * [ScriptX](#ScriptX)
-* [CppMediaServer](#CppMediaServer)
 * [moon](#moon)
 
 ## 孵化中
@@ -674,29 +673,3 @@ try {
 4. 支持脚本的异常处理
 5. API强类型
 
-## CppMediaServer
-
-项目名称：[Cpp Media Server](https://github.com/runner365/cpp_media_server)
-
-状态：已发布
-
-需要的C++版本：C++17
-
-项目简介：
-cpp media server是基于c++17开发的webrtc会议服务sfu，并且同时支持丰富的直播流媒体特性。
-
-支持跨平台(linux/mac)， 支持多种流媒体协议和封装格式：webrtc/rtmp/httpflv/hls/websocket flv
-
-### webrtc相关特性
-* 房间管理服务
-* websocket长连接接入
-* 推流/停止推流
-* 拉流/停止拉流
-* 高性能webrtc转rtmp
-* 高性能rtmp转webrtc
-
-### 直播相关特性
-* rtmp推拉流服务(支持h264/vp8+aac/opus in rtmp/flv)
-* httpflv拉流服务(支持h264/vp8+aac/opus in rtmp/flv)
-* hls录像服务(支持h264/vp8+aac/opus in mpegts)
-* webobs: websocket推送flv直播服务(webcodec编码，websocket flv推流封装)


### PR DESCRIPTION
webrtc sfu server的开源，直播流媒体的开源太多，开源意义不大，因此删除仓库